### PR TITLE
Новые параметры + отлаживание ошибок

### DIFF
--- a/src/Exceptions/RussianPostException.php
+++ b/src/Exceptions/RussianPostException.php
@@ -69,10 +69,7 @@ class RussianPostException extends \Exception
      */
     public function getErrorCode()
     {
-        if (array_key_exists('code', $this->response))
-            return $this->response['code'];
-
-        return '';
+        return !empty($this->response['code']) ? $this->response['code'] : '';
     }
 
     /**
@@ -80,10 +77,7 @@ class RussianPostException extends \Exception
      */
     public function getErrorDescription()
     {
-        if (array_key_exists('desc', $this->response))
-            return $this->response['desc'];
-
-        return '';
+        return !empty($this->response['desc']) ? $this->response['desc'] : '';
     }
 
     /**
@@ -91,9 +85,6 @@ class RussianPostException extends \Exception
      */
     public function getErrorSubCode()
     {
-        if (array_key_exists('sub-code', $this->response))
-            return $this->response['sub-code'];
-
-        return '';
+        return !empty($this->response['sub-code']) ? $this->response['sub-code'] : '';
     }
 }

--- a/src/Exceptions/RussianPostException.php
+++ b/src/Exceptions/RussianPostException.php
@@ -9,14 +9,26 @@ class RussianPostException extends \Exception
     private $raw_response = null;
 
     /**
+     * @var array
+     */
+    private $response = [];
+
+    /**
      * @var string
      */
-    private $raw_request  = null;
+    private $raw_request = null;
 
     public function __construct($message = "", $code = 0, $raw_response = null, $raw_request = null, $previous = null)
     {
         $this->raw_request = $raw_request;
         $this->raw_response = $raw_response;
+
+        $response = json_decode($this->getRawResponse(), true);
+        if ($response !== null && json_last_error() === JSON_ERROR_NONE)
+        {
+            $this->response = $response;
+        }
+
         parent::__construct($message, $code, $previous);
     }
 
@@ -50,5 +62,38 @@ class RussianPostException extends \Exception
     public function setRawRequest($raw_request)
     {
         $this->raw_request = $raw_request;
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorCode()
+    {
+        if (array_key_exists('code', $this->response))
+            return $this->response['code'];
+
+        return '';
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorDescription()
+    {
+        if (array_key_exists('desc', $this->response))
+            return $this->response['desc'];
+
+        return '';
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorSubCode()
+    {
+        if (array_key_exists('sub-code', $this->response))
+            return $this->response['sub-code'];
+
+        return '';
     }
 }

--- a/src/ParcelInfo.php
+++ b/src/ParcelInfo.php
@@ -8,6 +8,7 @@ class ParcelInfo
     private $courier = false; // Отметка 'Курьер'
     private $declaredValue = 0; // Объявленная ценность
     private $deliveryPointIndex = null; // Идентификатор пункта выдачи заказов
+    private $goodsValue = 0; // Стоимость (для ЕКОМ)
     private $height = 0; // Линейная высота (сантиметры)
     private $length = 0; // Линейная длина (сантиметры)
     private $width = 0; // Линейная ширина (сантиметры)
@@ -24,7 +25,9 @@ class ParcelInfo
     private $transportType = null; // Вид транспортировки https://otpravka.pochta.ru/specification#/enums-base-transport-type
     private $notify = false; // Отметка 'С заказным уведомлением'
     private $simpleNotify = false; // Отметка 'С простым уведомлением'
-  
+    private $functionalityChecking = false; // Признак услуги проверки работоспособности (для ЕКОМ)
+    private $withFitting = false; // Признак услуги 'Возможность примерки' (для ЕКОМ)
+
     /**
      * Возвращает данные по отправлению в виде массива для API ПРФ
      * @return array
@@ -43,6 +46,9 @@ class ParcelInfo
 
         if ($this->deliveryPointIndex)
             $array['delivery-point-index'] = $this->getDeliveryPointIndex();
+
+        if ($this->goodsValue)
+            $array['goods-value'] = $this->getGoodsValue();
 
         if ($this->declaredValue)
             $array['declared-value'] = $this->getDeclaredValue();
@@ -73,6 +79,8 @@ class ParcelInfo
 
         $array['with-order-of-notice'] = $this->isNotify();
         $array['with-simple-notice'] = $this->isSimpleNotify();
+        $array['functionality-checking'] = $this->isFunctionalityChecking();
+        $array['with-fitting'] = $this->isWithFitting();
 
         if (null !== $smsNotice = $this->getSmsNoticeRecipient()) {
             $array['sms-notice-recipient'] = (int)$smsNotice;
@@ -163,6 +171,22 @@ class ParcelInfo
     public function setDeliveryPointIndex($deliveryPointIndex)
     {
         $this->deliveryPointIndex = $deliveryPointIndex;
+    }
+
+    /**
+     * @return int
+     */
+    public function getGoodsValue()
+    {
+        return $this->goodsValue;
+    }
+
+    /**
+     * @param int $goodsValue
+     */
+    public function setGoodsValue($goodsValue)
+    {
+        $this->goodsValue = $goodsValue;
     }
 
     /**
@@ -387,6 +411,38 @@ class ParcelInfo
     public function setSimpleNotify($simpleNotify)
     {
         $this->simpleNotify = $simpleNotify;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFunctionalityChecking()
+    {
+        return $this->functionalityChecking;
+    }
+
+    /**
+     * @param bool $functionalityChecking
+     */
+    public function setFunctionalityChecking($functionalityChecking)
+    {
+        $this->functionalityChecking = $functionalityChecking;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isWithFitting()
+    {
+        return $this->withFitting;
+    }
+
+    /**
+     * @param bool $withFitting
+     */
+    public function setWithFitting($withFitting)
+    {
+        $this->withFitting = $withFitting;
     }
 
     /**

--- a/src/Providers/OtpravkaApi.php
+++ b/src/Providers/OtpravkaApi.php
@@ -203,6 +203,9 @@ class OtpravkaApi implements LoggerAwareInterface
         if ($response->getStatusCode() == 400 && !empty($resp['error']))
             throw new RussianPostException('От сервера Почты России при вызове метода '.$method.' получена ошибка: '.$resp['error'] . " (".$resp['status'].")", $response->getStatusCode(), $response_contents, $request);
 
+        if ($response->getStatusCode() == 400  && (!empty($resp['code']) || !empty($resp['desc']) || !empty($resp['sub-code'])))
+            throw new RussianPostException('От сервера Почты России при вызове метода '.$method.' получена ошибка', $response->getStatusCode(), $response_contents, $request);
+
         if (!empty($resp['error']))
             throw new RussianPostException('От сервера Почты России при вызове метода '.$method.' получена ошибка: '.$resp['error'] . " (".$resp['status'].")", $response->getStatusCode(), $response_contents, $request);
 

--- a/src/Providers/OtpravkaApi.php
+++ b/src/Providers/OtpravkaApi.php
@@ -194,20 +194,17 @@ class OtpravkaApi implements LoggerAwareInterface
             return $response_contents;
         }
 
+        if ($response->getStatusCode() != 200 && !empty($resp['code']))
+            throw new RussianPostException('От сервера Почты России при вызове метода '.$method.' получена ошибка: '.$resp['sub-code'] . " (".$resp['code'].")", $response->getStatusCode(), $response_contents, $request);
+
         if ($response->getStatusCode() == 407 && !empty($resp['status']) && $resp['status'] == 'ERROR')
             throw new RussianPostException('От сервера Почты России при вызове метода '.$method.' получена ошибка: '.$resp['message'] . " (".$resp['status'].")", $response->getStatusCode(), $response_contents, $request);
-
-        if ($response->getStatusCode() == 404 && !empty($resp['code']))
-            throw new RussianPostException('От сервера Почты России при вызове метода '.$method.' получена ошибка: '.$resp['sub-code'] . " (".$resp['code'].")", $response->getStatusCode(), $response_contents, $request);
 
         if ($response->getStatusCode() == 400 && !empty($resp['error']))
             throw new RussianPostException('От сервера Почты России при вызове метода '.$method.' получена ошибка: '.$resp['error'] . " (".$resp['status'].")", $response->getStatusCode(), $response_contents, $request);
 
         if ($response->getStatusCode() == 400  && (!empty($resp['code']) || !empty($resp['desc']) || !empty($resp['sub-code'])))
             throw new RussianPostException('От сервера Почты России при вызове метода '.$method.' получена ошибка', $response->getStatusCode(), $response_contents, $request);
-
-        if (!empty($resp['error']))
-            throw new RussianPostException('От сервера Почты России при вызове метода '.$method.' получена ошибка: '.$resp['error'] . " (".$resp['status'].")", $response->getStatusCode(), $response_contents, $request);
 
         return $resp;
     }

--- a/src/Providers/OtpravkaApi.php
+++ b/src/Providers/OtpravkaApi.php
@@ -203,9 +203,6 @@ class OtpravkaApi implements LoggerAwareInterface
         if ($response->getStatusCode() == 400 && !empty($resp['error']))
             throw new RussianPostException('От сервера Почты России при вызове метода '.$method.' получена ошибка: '.$resp['error'] . " (".$resp['status'].")", $response->getStatusCode(), $response_contents, $request);
 
-        if ($response->getStatusCode() == 400  && (!empty($resp['code']) || !empty($resp['desc']) || !empty($resp['sub-code'])))
-            throw new RussianPostException('От сервера Почты России при вызове метода '.$method.' получена ошибка', $response->getStatusCode(), $response_contents, $request);
-
         return $resp;
     }
 

--- a/src/TariffInfo.php
+++ b/src/TariffInfo.php
@@ -26,6 +26,10 @@ class TariffInfo
     private $fragileRate = 0; // Тариф без НДС (коп)
     private $fragileNds = 0; // НДС (коп)
 
+    // Плата за услугу проверки работоспособности
+    private $functionalityCheckingRate = 0; // Тариф без НДС (коп)
+    private $functionalityCheckingNds = 0; // НДС (коп)
+
     // Плата за пересылку
     private $groundRate = 0; // Тариф без НДС (коп)
     private $groundNds = 0; // НДС (коп)
@@ -41,6 +45,10 @@ class TariffInfo
     // Надбавка за негабарит при весе более 10кг
     private $oversizeRate = 0; // Тариф без НДС (коп)
     private $oversizeNds = 0; // НДС (коп)
+    
+    // Плата за услугу примерки
+    private $withFittingRate = 0; // Тариф без НДС (коп);
+    private $withFittingNds = 0; // НДС (коп)
 
     /**
      * TariffInfo constructor
@@ -93,6 +101,14 @@ class TariffInfo
         if (!empty($rawData['fragile-rate']) && !empty($rawData['fragile-rate']['vat'])) {
             $this->setFragileNds($rawData['fragile-rate']['vat']);
         }
+        
+        if (!empty($rawData['functionality-checking-rate']) && !empty($rawData['functionality-checking-rate']['rate'])) {
+            $this->setFunctionalityCheckingRate($rawData['functionality-checking-rate']['rate']);
+        }
+        
+        if (!empty($rawData['functionality-checking-rate']) && !empty($rawData['functionality-checking-rate']['vat'])) {
+            $this->setFunctionalityCheckingNds($rawData['functionality-checking-rate']['vat']);
+        }
 
         if (!empty($rawData['ground-rate']) && !empty($rawData['ground-rate']['rate'])) {
             $this->setGroundRate($rawData['ground-rate']['rate']);
@@ -124,6 +140,14 @@ class TariffInfo
 
         if (!empty($rawData['oversize-rate']) && !empty($rawData['oversize-rate']['vat'])) {
             $this->setOversizeNds($rawData['oversize-rate']['vat']);
+        }
+
+        if (!empty($rawData['with-fitting-rate']) && !empty($rawData['with-fitting-rate']['rate'])) {
+            $this->setWithFittingRate($rawData['with-fitting-rate']['rate']);
+        }
+        
+        if (!empty($rawData['with-fitting-rate']) && !empty($rawData['with-fitting-rate']['vat'])) {
+            $this->setWithFittingNds($rawData['with-fitting-rate']['vat']);
         }
     }
 
@@ -322,6 +346,38 @@ class TariffInfo
     /**
      * @return int
      */
+    public function getFunctionalityCheckingRate()
+    {
+        return $this->functionalityCheckingRate;
+    }
+
+    /**
+     * @param int $functionalityCheckingRate
+     */
+    public function setFunctionalityCheckingRate($functionalityCheckingRate)
+    {
+        $this->functionalityCheckingRate = $functionalityCheckingRate;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFunctionalityCheckingNds()
+    {
+        return $this->functionalityCheckingNds;
+    }
+
+    /**
+     * @param int $functionalityCheckingNds
+     */
+    public function setFunctionalityCheckingNds($functionalityCheckingNds)
+    {
+        $this->functionalityCheckingNds = $functionalityCheckingNds;
+    }
+
+    /**
+     * @return int
+     */
     public function getGroundRate()
     {
         return $this->groundRate;
@@ -445,5 +501,37 @@ class TariffInfo
     public function setOversizeNds($oversizeNds)
     {
         $this->oversizeNds = $oversizeNds;
+    }
+
+    /**
+     * @return int
+     */
+    public function getWithFittingRate()
+    {
+        return $this->withFittingRate;
+    }
+
+    /**
+     * @param int $withFittingRate
+     */
+    public function setWithFittingRate($withFittingRate)
+    {
+        $this->withFittingRate = $withFittingRate;
+    }
+
+    /**
+     * @return int
+     */
+    public function getWithFittingNds()
+    {
+        return $this->withFittingNds;
+    }
+
+    /**
+     * @param int $withFittingNds
+     */
+    public function setWithFittingNds($withFittingNds)
+    {
+        $this->withFittingNds = $withFittingNds;
     }
 }


### PR DESCRIPTION
Дополнен список принимаемых тарификатором параметров посылки ЕКОМ-параметрами: "goods-value", "functionality-checking", "with-fitting".

Дополнен список возвращаемых тарификатором параметров расчета: добавлены "functionality-checking-rate", "with-fitting-rate".

Добавлены дополнительные параметры для ошибки со стороны API Почты: "code", "desc" и "sub-code".

Запрос к API теперь откидывает ошибку RussianPostException при статусе ответа не 200 и наличии информации об ошибке ("code" в ответе).