### PR TITLE
Исправление ошибки при изменении типа клиента

### DIFF
--- a/src/Providers/Tracking.php
+++ b/src/Providers/Tracking.php
@@ -49,14 +49,14 @@ class Tracking implements LoggerAwareInterface
         $this->service = $service;
 
         if($service != 'pack') {
-            $this->wsdl .= '/tracking-web-static/rtm34_wsdl.xml';
+            $wsdl = $this->wsdl . '/tracking-web-static/rtm34_wsdl.xml';
             $soapVersion = SOAP_1_2;
         } else {
-            $this->wsdl .= '/tracking-web-static/fc_wsdl.xml';
+            $wsdl = $this->wsdl . '/tracking-web-static/fc_wsdl.xml';
             $soapVersion = SOAP_1_1;
         }
 
-        $this->client = new \SoapClient($this->wsdl, array(
+        $this->client = new \SoapClient($wsdl, array(
                 'trace' => 1,
                 'soap_version' => $soapVersion,
                 'use' => SOAP_LITERAL,


### PR DESCRIPTION
SOAP-ERROR: Parsing WSDL: Couldn't load from 'https://tracking.pochta.ru/tracking-web-static/rtm34_wsdl.xml/tracking-web-static/fc_wsdl.xml' : failed to load external entity "https://tracking.pochta.ru/tracking-web-static/rtm34_wsdl.xml/tracking-web-static/fc_wsdl.xml"