### PR TITLE
Добавил новое свойство lineattr в объект Item

### DIFF
--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -11,6 +11,8 @@ Class Item
 {
     /** @var string|null  */
     private $code = null; // Код (маркировка) товара
+    /** @var int  */
+    private $lineattr = 1; // Признак предмета расчета. См. Справочнк признаков предмета расчета
     /** @var string  */
     private $description = ''; // Наименование товара
     /** @var int|null  */
@@ -43,6 +45,22 @@ Class Item
     public function setCode($code)
     {
         $this->code = $code;
+    }
+    
+    /**
+     * @return int
+     */
+    public function getLineAttr()
+    {
+        return $this->lineattr;
+    }
+    
+    /**
+     * @param int
+     */
+    public function setLineAttr($lineattr)
+    {
+        $this->lineattr = $lineattr;
     }
 
     /**

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace LapayGroup\RussianPost\Entity;
 
 /**
@@ -7,12 +8,22 @@ namespace LapayGroup\RussianPost\Entity;
  * Class Item
  * @package LapayGroup\RussianPost\Entity
  */
-Class Item
+class Item
 {
     /** @var string|null  */
     private $code = null; // Код (маркировка) товара
-    /** @var int  */
-    private $lineattr = 1; // Признак предмета расчета. См. Справочнк признаков предмета расчета
+    /** @var int|null  */
+    private $lineattr = null; // Признак предмета расчета. См. Справочнк признаков предмета расчета
+    /** @var int|null  */
+    private $payattr  = null; // Признак способа расчета. См. Признаки способов расчета
+    /** @var string  */
+    private $goods_type = null; // Признак товар или услуга. См. Тип вложения
+    /** @var int|null  */
+    private $country_code = null; // Код страны происхождения. См. Список стран
+    /** @var string|null  */
+    private $customs_declaration_number = null; // Номер таможенной декларации
+    /** @var int|null  */
+    private $excise = null; // Акциз
     /** @var string  */
     private $description = ''; // Наименование товара
     /** @var int|null  */
@@ -30,6 +41,9 @@ Class Item
     private $value = 0; // Цена товара (вкл. НДС)
     /** @var int  */
     private $vat_rate = -1; // Ставка НДС: Без НДС(-1), 0, 10, 20
+    /** @var int|null  */
+    private $weight = null; // Вес товара (в граммах)
+
 
     /**
      * @return string|null
@@ -46,22 +60,100 @@ Class Item
     {
         $this->code = $code;
     }
-    
+
     /**
-     * @return int
+     * @return int|null
      */
     public function getLineAttr()
     {
         return $this->lineattr;
     }
-    
+
     /**
-     * @param int
+     * @param int|null $lineattr
      */
     public function setLineAttr($lineattr)
     {
         $this->lineattr = $lineattr;
     }
+
+    /**
+     * @return int|null
+     */
+    public function getPayAttr()
+    {
+        return $this->payattr;
+    }
+
+    /**
+     * @param int|null $payattr
+     */
+    public function setPayAttr($payattr)
+    {
+        $this->lineattr = $payattr;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getGoodsType()
+    {
+        return $this->goods_type;
+    }
+
+    /**
+     * @param string|null $goods_type
+     */
+    public function setGoodsType($goods_type)
+    {
+        $this->lineattr = $goods_type;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getСountryCode()
+    {
+        return $this->country_code;
+    }
+
+    /**
+     * @param int|null $country_code
+     */
+    public function setСountryCode($country_code)
+    {
+        $this->code = $country_code;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getСustomsDeclarationNumber()
+    {
+        return $this->customs_declaration_number;
+    }
+    /**
+     * @param string|null $customs_declaration_number
+     */
+    public function setСustomsDeclarationNumber($customs_declaration_number)
+    {
+        $this->code = $customs_declaration_number;
+    }
+    /**
+     * @return int|null
+     */
+    public function getExcise()
+    {
+        return $this->excise;
+    }
+    /**
+     * @param int|null $excise
+     */
+    public function setExcise($excise)
+    {
+        $this->code = $excise;
+    }
+
 
     /**
      * @return string
@@ -205,5 +297,21 @@ Class Item
     public function setVatRate($vat_rate)
     {
         $this->vat_rate = $vat_rate;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getWeight()
+    {
+        return $this->weight;
+    }
+
+    /**
+     * @param int|null $weight
+     */
+    public function setWeight($weight)
+    {
+        $this->vat_rate = $weight;
     }
 }

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -309,6 +309,18 @@ Class Order
                 if (!is_null($item->getCode()))
                     $order_item['code'] = $item->getCode();
 
+                if (!is_null($item->getСountryCode()))
+                    $order_item['country-code'] = $item->getСountryCode();
+
+                if (!is_null($item->getLineAttr()))
+                    $order_item['lineattr'] = (int)$item->getLineAttr();
+
+                if (!is_null($item->getPayAttr()))
+                    $order_item['payattr'] = (int)$item->getPayAttr();
+
+                if (!is_null($item->getGoodsType()))
+                    $order_item['goods-type'] = (string)$item->getGoodsType();
+
                 if (!is_null($item->getInsrValue()))
                     $order_item['insr-value'] = (int)$item->getInsrValue();
 
@@ -329,9 +341,15 @@ Class Order
 
                 if (!is_null($item->getVatRate()))
                     $order_item['vat-rate'] = (int)$item->getVatRate();
-                
-                if (!is_null($item->getLineAttr()))
-                    $order_item['lineattr'] = (int)$item->getLineAttr();
+
+                if (!is_null($item->getСustomsDeclarationNumber()))
+                    $order_item['customs-declaration-number'] = (string)$item->getСustomsDeclarationNumber();
+
+                if (!is_null($item->getExcise()))
+                    $order_item['excise'] = (string)$item->getExcise();
+
+                if (!is_null($item->getWeight()))
+                    $order_item['weight'] = (int)$item->getWeight();
 
                 $request['goods']['items'][] = $order_item;
             }

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -329,6 +329,9 @@ Class Order
 
                 if (!is_null($item->getVatRate()))
                     $order_item['vat-rate'] = (int)$item->getVatRate();
+                
+                if (!is_null($item->getLineAttr()))
+                    $order_item['lineattr'] = (int)$item->getLineAttr();
 
                 $request['goods']['items'][] = $order_item;
             }


### PR DESCRIPTION
Новое свойство в товаре lineattr, Признак предмета расчета. Может принимать числовые значения указанные здесь https://otpravka.pochta.ru/specification#/enums-lineattr Информация о нем разнится. В доках к api почты стоит как опциональное. Но при создании заказа через ЛК почты России не указано как необязательно. И это не случайно!  У продавца по закону идет обязанность указывать в кассовом чеке значения реквизита «признак предмета расчета». Без него может не пройти расчет. По умолчанию поставил, 1, т.е. Товар. Так что лучше, чтобы оно было указано. Менять его можно через соответствующую функцию setLineAttr

После добавления нового свойства lineattr в Item нужно сделать getLineAttr в Order, чтобы оно "заработало"
