### PR TITLE
Fix for php 8.2 compatibility

### DIFF
--- a/src/Providers/OtpravkaApi.php
+++ b/src/Providers/OtpravkaApi.php
@@ -51,6 +51,9 @@ class OtpravkaApi implements LoggerAwareInterface
     /** @var \GuzzleHttp\Client */
     private $postOfficeClient = null;
 
+    /** @var array */
+    private $config = null;
+
     function __construct($config, $timeout = 60)
     {
         $this->config = $config;


### PR DESCRIPTION
Since PHP 8.2 does not allow add dynamic properties to non stdClass objects, each property should be defined in class before referencing it in code.

This PR fixed code to comply php 8.2 requirements